### PR TITLE
fix: upgrade provider to 1.54.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To attach access management tags to resources in this module, you need the follo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.54.0, < 2.0.0 |
 
 ## Modules
 

--- a/examples/backup/version.tf
+++ b/examples/backup/version.tf
@@ -1,10 +1,10 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
-    # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
+    # Use latest version of provider in non-basic examples to verify latest version works with module
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = ">= 1.54.0"
     }
   }
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = "1.54.0"
     }
   }
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -1,10 +1,10 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
-    # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
+    # Use latest version of provider in non-basic examples to verify latest version works with module
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.54.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -1,10 +1,10 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
-    # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
+    # Use latest version of provider in non-basic examples to verify latest version works with module
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = ">= 1.54.0"
     }
   }
 }

--- a/examples/pitr/version.tf
+++ b/examples/pitr/version.tf
@@ -1,10 +1,10 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
-    # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
+    # Use latest version of provider in non-basic examples to verify latest version works with module
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = ">= 1.54.0"
     }
   }
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -455,7 +455,7 @@
     "ibm": {
       "source": "IBM-Cloud/ibm",
       "version_constraints": [
-        "\u003e= 1.49.0"
+        "\u003e= 1.54.0, \u003c 2.0.0"
       ]
     }
   },

--- a/profiles/fscloud/README.md
+++ b/profiles/fscloud/README.md
@@ -16,7 +16,7 @@ The IBM Cloud Framework for Financial Services mandates the application of an in
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.54.0 |
 
 ## Modules
 

--- a/profiles/fscloud/version.tf
+++ b/profiles/fscloud/version.tf
@@ -8,7 +8,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # Use "greater than or equal to" range in modules
-      version = ">= 1.49.0"
+      version = ">= 1.54.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.54.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description
Bump provider version to pick up bug fix for auth policies in 1.54.0


### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [x] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content
Update IBM provider to v1.54.0


### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
