### PR TITLE
fix: Fix output error for hostname and port

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -41,10 +41,10 @@ output "cbr_rule_ids" {
 
 output "hostname" {
   description = "Database hostname. Only contains value when var.service_credential_names or var.users are set."
-  value       = length(var.service_credential_names) > 0 ? nonsensitive(ibm_resource_key.service_credentials[keys(var.service_credential_names)[0]].credentials["connection.postgres.hosts.0.hostname"]) : length(var.users) > 0 ? nonsensitive(flatten(data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].hostname)) : null
+  value       = length(var.service_credential_names) > 0 ? nonsensitive(ibm_resource_key.service_credentials[keys(var.service_credential_names)[0]].credentials["connection.postgres.hosts.0.hostname"]) : length(var.users) > 0 ? data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].hostname : null
 }
 
 output "port" {
   description = "Database port. Only contains value when var.service_credential_names or var.users are set."
-  value       = length(var.service_credential_names) > 0 ? nonsensitive(ibm_resource_key.service_credentials[keys(var.service_credential_names)[0]].credentials["connection.postgres.hosts.0.port"]) : length(var.users) > 0 ? nonsensitive(flatten(data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].port)) : null
+  value       = length(var.service_credential_names) > 0 ? nonsensitive(ibm_resource_key.service_credentials[keys(var.service_credential_names)[0]].credentials["connection.postgres.hosts.0.port"]) : length(var.users) > 0 ? data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].port : null
 }


### PR DESCRIPTION
### Description

When using this module we get this error:

```
 2023/08/11 07:34:22 Terraform apply | 
 2023/08/11 07:34:22 Terraform apply | Error: Error in function call
 2023/08/11 07:34:22 Terraform apply | 
 2023/08/11 07:34:22 Terraform apply |   on .terraform/modules/icd_postgresql/outputs.tf line 44, in output "hostname":
 2023/08/11 07:34:22 Terraform apply |   44:   value       = length(var.service_credential_names) > 0 ? nonsensitive(ibm_resource_key.service_credentials[keys(var.service_credential_names)[0]].credentials["connection.postgres.hosts.0.hostname"]) : length(var.users) > 0 ? nonsensitive(flatten(data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].hostname)) : null
 2023/08/11 07:34:22 Terraform apply |     ├────────────────
 2023/08/11 07:34:22 Terraform apply |     │ while calling flatten(list)
 2023/08/11 07:34:22 Terraform apply |     │ data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].hostname is "215daa49-149e-497c-9985-171ad7234915.497129fd685f442ca4df759dd55ec01b.databases.appdomain.cloud"
 2023/08/11 07:34:22 Terraform apply | 
 2023/08/11 07:34:22 Terraform apply | Call to function "flatten" failed: can only flatten lists, sets and tuples.
 2023/08/11 07:34:22 Terraform apply | 
 2023/08/11 07:34:22 Terraform apply | Error: Error in function call
 2023/08/11 07:34:22 Terraform apply | 
 2023/08/11 07:34:22 Terraform apply |   on .terraform/modules/icd_postgresql/outputs.tf line 49, in output "port":
 2023/08/11 07:34:22 Terraform apply |   49:   value       = length(var.service_credential_names) > 0 ? nonsensitive(ibm_resource_key.service_credentials[keys(var.service_credential_names)[0]].credentials["connection.postgres.hosts.0.port"]) : length(var.users) > 0 ? nonsensitive(flatten(data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].port)) : null
 2023/08/11 07:34:22 Terraform apply |     ├────────────────
 2023/08/11 07:34:22 Terraform apply |     │ while calling flatten(list)
 2023/08/11 07:34:22 Terraform apply |     │ data.ibm_database_connection.database_connection[0].postgres[0].hosts[0].port is 30965
 2023/08/11 07:34:22 Terraform apply | 
 2023/08/11 07:34:22 Terraform apply | Call to function "flatten" failed: can only flatten lists, sets and tuples.
 ```

The [terraform provider documentation](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/database_connection#hosts) states that the hostname and port are strings and those can't be flattened. Therefore this PR removes this part.

### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
