### PR TITLE
fix: resolve double prefix on vpc name

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -43,7 +43,7 @@ module "vpc" {
   resource_group_id = module.resource_group.resource_group_id
   region            = var.region
   prefix            = var.prefix
-  name              = "${var.prefix}-vpc"
+  name              = "vpc"
   tags              = var.resource_tags
 }
 


### PR DESCRIPTION
### Description

In the complete example, the VPC passes a prefix AND a name containing the prefix to the vpc module. The vpc module adds the prefix to the name every time it uses the name, so this results in a double prefix on many names.

It also causes the upgrade tests to fail.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This is an example change, no impact to consumers of the module.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
