### PR TITLE
test: use default region when searching regions dynamically

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -17,6 +17,7 @@ func TestRunRestoredDBExample(t *testing.T) {
 		TerraformDir:       "examples/backup",
 		Prefix:             "pg-backup",
 		BestRegionYAMLPath: regionSelectionPath,
+		DefaultRegion:      "us-south",
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
 			"pg_version": "13",
@@ -60,6 +61,7 @@ func TestRunBasicExample(t *testing.T) {
 		TerraformDir:       "examples/basic",
 		Prefix:             "postgres",
 		BestRegionYAMLPath: regionSelectionPath,
+		DefaultRegion:      "us-south",
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
 			"pg_version": "12",
@@ -105,6 +107,7 @@ func TestRunCompleteExample(t *testing.T) {
 		TerraformDir:       "examples/complete",
 		Prefix:             "pg-complete",
 		BestRegionYAMLPath: regionSelectionPath,
+		DefaultRegion:      "us-south",
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
 			"pg_version": "12",

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -93,6 +93,7 @@ func TestRunUpgradeCompleteExample(t *testing.T) {
 		TerraformDir:       "examples/complete",
 		Prefix:             "postgres-upg",
 		BestRegionYAMLPath: regionSelectionPath,
+		DefaultRegion:      "us-south",
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
 			"pg_version": "12", // Always lock to the lowest supported Postgres version
@@ -123,6 +124,7 @@ func TestRunBasicExampleWithFlavor(t *testing.T) {
 		TerraformDir:       "examples/basic",
 		Prefix:             "postgres-flvr",
 		BestRegionYAMLPath: regionSelectionPath,
+		DefaultRegion:      "us-south",
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
 			"member_host_flavor": "b3c.4x16.encrypted",


### PR DESCRIPTION
### Description

use default region when searching regions dynamically.

Issue: https://github.ibm.com/GoldenEye/issues/issues/8701

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
