### PR TITLE
fix: workaround group on restore

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -123,7 +123,7 @@ module "postgresql_db" {
     tcp_keepalives_interval    = 50
     tcp_keepalives_count       = 6
     archive_timeout            = 1000
-    wal_level                  = "hot_standby"
+    wal_level                  = "replica"
     max_replication_slots      = 10
     max_wal_senders            = 20
   }

--- a/main.tf
+++ b/main.tf
@@ -82,11 +82,14 @@ resource "ibm_database" "postgresql_db" {
     }
   }
 
+  # Workaround for https://github.ibm.com/GoldenEye/issues/issues/11359
+  # means that no `group` block is added when restoring from backup
+
   ## This for_each block is NOT a loop to attach to multiple group blocks.
   ## This is used to conditionally add one, OR, the other group block depending on var.local.host_flavor_set
   ## This block is for if host_flavor IS set to specific pre-defined host sizes and not set to "multitenant"
   dynamic "group" {
-    for_each = local.host_flavor_set && var.member_host_flavor != "multitenant" ? [1] : []
+    for_each = local.host_flavor_set && var.member_host_flavor != "multitenant" && var.backup_crn == null ? [1] : []
     content {
       group_id = "member" # Only member type is allowed for IBM Cloud Databases
       host_flavor {
@@ -106,7 +109,7 @@ resource "ibm_database" "postgresql_db" {
 
   ## This block is for if host_flavor IS set to "multitenant"
   dynamic "group" {
-    for_each = local.host_flavor_set && var.member_host_flavor == "multitenant" ? [1] : []
+    for_each = local.host_flavor_set && var.member_host_flavor == "multitenant" && var.backup_crn == null ? [1] : []
     content {
       group_id = "member" # Only member type is allowed for IBM Cloud Databases
       host_flavor {
@@ -132,7 +135,7 @@ resource "ibm_database" "postgresql_db" {
 
   ## This block is for if host_flavor IS NOT set
   dynamic "group" {
-    for_each = local.host_flavor_set ? [] : [1]
+    for_each = local.host_flavor_set && var.backup_crn == null ? [] : [1]
     content {
       group_id = "member" # Only member type is allowed for IBM Cloud Databases
       memory {

--- a/main.tf
+++ b/main.tf
@@ -195,6 +195,8 @@ resource "ibm_database" "postgresql_db" {
 
   timeouts {
     create = "120m" # Extending provisioning time to 120 minutes
+    update = "120m"
+    delete = "15m"
   }
 }
 

--- a/solutions/standard/DA-types.md
+++ b/solutions/standard/DA-types.md
@@ -162,7 +162,7 @@ The configuration object in the input contains the following options categorized
 **3. WAL Settings. [Learn more](https://cloud.ibm.com/docs/databases-for-postgresql?topic=databases-for-postgresql-changing-configuration&interface=cli#wal-settings).**
 
 - `archive_timeout`: Forces a switch to the next WAL file if no new file has been generated within the specified time. Useful for ensuring regular WAL archiving. (default: `1800`)
-- `wal_level`: Sets the level of information written to the WAL. Higher levels, like replica or logical, are required for replication and logical decoding. (default: `hot_standby`)
+- `wal_level`: Sets the level of information written to the WAL. Higher levels, like replica or logical, are required for replication and logical decoding. (default: `replica`)
 - `max_replication_slots`: Specifies the maximum number of replication slots, which are used for streaming replication and logical decoding. (default: `10`)
 - `max_wal_senders`: Determines the maximum number of concurrent WAL sender processes for streaming replication. Increasing this allows more standby servers to connect. (default: `12`)
 
@@ -185,7 +185,7 @@ The following example shows values for the `configuration` input.
     "tcp_keepalives_interval": 15,
     "tcp_keepalives_count": 6,
     "archive_timeout": 1800,
-    "wal_level": "hot_standby",
+    "wal_level": "replica",
     "max_replication_slots": 10,
     "max_wal_senders": 12
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -159,7 +159,7 @@ variable "configuration" {
     tcp_keepalives_interval    = 15
     tcp_keepalives_count       = 6
     archive_timeout            = 1800
-    wal_level                  = "hot_standby"
+    wal_level                  = "replica"
     max_replication_slots      = 10
     max_wal_senders            = 12
   }

--- a/variables.tf
+++ b/variables.tf
@@ -203,8 +203,8 @@ variable "configuration" {
   }
 
   validation {
-    condition     = var.configuration != null ? (var.configuration["wal_level"] != null ? contains(["hot_standby", "logical"], var.configuration["wal_level"]) : true) : true
-    error_message = "Value for `configuration[\"wal_level\"]` must be either `hot_standby` or `logical`, if specified."
+    condition     = var.configuration != null ? (var.configuration["wal_level"] != null ? contains(["replica", "logical"], var.configuration["wal_level"]) : true) : true
+    error_message = "Value for `configuration[\"wal_level\"]` must be either `replica` or `logical`, if specified."
   }
 
   validation {


### PR DESCRIPTION
### Description

Add a work around to remove the `group` block when restoring from a backup.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Avoid defining the host_flavor during restore operations.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
