### PR TITLE
fix: remove wal_level default values and validation

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -123,7 +123,6 @@ module "postgresql_db" {
     tcp_keepalives_interval    = 50
     tcp_keepalives_count       = 6
     archive_timeout            = 1000
-    wal_level                  = "replica"
     max_replication_slots      = 10
     max_wal_senders            = 20
   }

--- a/solutions/standard/DA-types.md
+++ b/solutions/standard/DA-types.md
@@ -185,7 +185,6 @@ The following example shows values for the `configuration` input.
     "tcp_keepalives_interval": 15,
     "tcp_keepalives_count": 6,
     "archive_timeout": 1800,
-    "wal_level": "replica",
     "max_replication_slots": 10,
     "max_wal_senders": 12
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -159,7 +159,6 @@ variable "configuration" {
     tcp_keepalives_interval    = 15
     tcp_keepalives_count       = 6
     archive_timeout            = 1800
-    wal_level                  = "replica"
     max_replication_slots      = 10
     max_wal_senders            = 12
   }

--- a/variables.tf
+++ b/variables.tf
@@ -202,10 +202,11 @@ variable "configuration" {
     error_message = "Value for `configuration[\"archive_timeout\"]` must be 300 or more, if specified."
   }
 
-  validation {
-    condition     = var.configuration != null ? (var.configuration["wal_level"] != null ? contains(["replica", "logical"], var.configuration["wal_level"]) : true) : true
-    error_message = "Value for `configuration[\"wal_level\"]` must be either `replica` or `logical`, if specified."
-  }
+  # skip validation for issue #508 and #512
+  #validation {
+  #  condition     = var.configuration != null ? (var.configuration["wal_level"] != null ? contains(["replica", "logical"], var.configuration["wal_level"]) : true) : true
+  #  error_message = "Value for `configuration[\"wal_level\"]` must be either `replica` or `logical`, if specified."
+  #}
 
   validation {
     condition     = var.configuration != null ? (var.configuration["max_replication_slots"] != null ? var.configuration["max_replication_slots"] >= 10 : true) : true


### PR DESCRIPTION
### Description

Following on from #508 and #512, remove the wal_level is being hidden.

Consumers can still set a value, since the field is still present and optional.
The default values no longer set wal_level and the validation is removed.

This PR will need revert / updating when the service changes are deployed

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
