### PR TITLE
fix: logic when host flavour not set

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -45,16 +45,17 @@ resource "time_sleep" "wait_time" {
 ##############################################################################
 
 module "read_only_replica_postgresql_db" {
-  count             = var.read_only_replicas_count
-  source            = "../.."
-  resource_group_id = module.resource_group.resource_group_id
-  name              = "${var.prefix}-read-only-replica-${count.index}"
-  region            = var.region
-  resource_tags     = var.resource_tags
-  access_tags       = var.access_tags
-  pg_version        = var.pg_version
-  remote_leader_crn = module.postgresql_db.crn
-  member_memory_mb  = 2304  # Must be an increment of 384 megabytes. The minimum size of a read-only replica is 2 GB RAM
-  member_disk_mb    = 15360 # Must be an increment of 512 megabytes. The minimum size of a read-only replica is 15.36 GB of disk
-  depends_on        = [time_sleep.wait_time]
+  count              = var.read_only_replicas_count
+  source             = "../.."
+  resource_group_id  = module.resource_group.resource_group_id
+  name               = "${var.prefix}-read-only-replica-${count.index}"
+  region             = var.region
+  resource_tags      = var.resource_tags
+  access_tags        = var.access_tags
+  pg_version         = var.pg_version
+  remote_leader_crn  = module.postgresql_db.crn
+  member_host_flavor = "multitenant"
+  member_memory_mb   = 4096  # Must be an increment of 384 megabytes. The minimum size of a read-only replica is 2 GB RAM, new hosting model minimum is 4 GB RAM.
+  member_disk_mb     = 15360 # Must be an increment of 512 megabytes. The minimum size of a read-only replica is 15.36 GB of disk
+  depends_on         = [time_sleep.wait_time]
 }

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "ibm_database" "postgresql_db" {
 
   ## This block is for if host_flavor IS NOT set
   dynamic "group" {
-    for_each = local.host_flavor_set && var.backup_crn == null ? [] : [1]
+    for_each = local.host_flavor_set == false && var.backup_crn == null ? [1] : []
     content {
       group_id = "member" # Only member type is allowed for IBM Cloud Databases
       memory {


### PR DESCRIPTION
### Description

Fix an issue in the original ICD hosting model logic for conditionally including the group block during a database restore operation.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
