### PR TITLE
fix: reduce memory usage in test

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -23,7 +23,6 @@ module "postgresql_db" {
   resource_tags      = var.resource_tags
   access_tags        = var.access_tags
   member_host_flavor = var.member_host_flavor
-  member_memory_mb   = var.member_memory_mb
 }
 
 # On destroy, we are seeing that even though the replica has been returned as

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -56,9 +56,3 @@ variable "member_host_flavor" {
   description = "Allocated host flavor per member. For more information, see https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database#host_flavor"
   default     = null
 }
-
-variable "member_memory_mb" {
-  type        = number
-  description = "Allocated memory per-member. See the following doc for supported values: https://cloud.ibm.com/docs/databases-for-postgresql?topic=databases-for-postgresql-resources-scaling"
-  default     = 4096
-}

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -130,7 +130,6 @@ func TestRunBasicExampleWithFlavorMultitenant(t *testing.T) {
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
 			"member_host_flavor": "multitenant",
-			"member_memory_mb":   8192, // Requires a minimum of 8192 megabytes with multitenant flavor
 		},
 		CloudInfoService: sharedInfoSvc,
 	})


### PR DESCRIPTION
### Description

Simplify the memory model used for basic testing. 4096 is the minimum size. 
The multitenant other_test.go has been run and passed locally with the new lower memory.

Note: Error messages reporting 8192 (or more) are just multiplying the 4096 by the number of members.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
