### PR TITLE
fix: use code editor in IBM catalog for maps/objects

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -271,7 +271,12 @@
               "key": "auto_scaling"
             },
             {
-              "key": "configuration"
+              "key": "configuration",
+              "custom_config": {
+                "type": "code_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
             },
             {
               "key": "service_endpoints",
@@ -300,7 +305,12 @@
               "key": "version_upgrade_skip_backup"
             },
             {
-              "key": "service_credential_names"
+              "key": "service_credential_names",
+              "custom_config": {
+                "type": "code_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
             },
             {
               "key": "service_credential_secrets",
@@ -610,7 +620,12 @@
               "key": "auto_scaling"
             },
             {
-              "key": "configuration"
+              "key": "configuration",
+              "custom_config": {
+                "type": "code_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
             },
             {
               "key": "deletion_protection"
@@ -619,7 +634,12 @@
               "key": "timeouts_update"
             },
             {
-              "key": "service_credential_names"
+              "key": "service_credential_names",
+              "custom_config": {
+                "type": "code_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
             },
             {
               "key": "service_credential_secrets",


### PR DESCRIPTION
### Description

For the catalog entry, use the code editor for map and object types. The editor is already used for list (array) types.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
